### PR TITLE
Implement bundler mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Configured correctly it will:
 
 # Usage
 
+## spec strategy (default)
+
 * You need a `Gemfile` and `Gemfile.lock` among your sources. If you have a tarball, consider using
   the [extract_file](https://github.com/openSUSE/obs-service-extract_file) service to extract them.
   
@@ -100,6 +102,20 @@ $bundle config build.nokogiri --use-system-libraries
 $bundle --local --deployment --with production
 ```
 
+## cpio mode
+Compared to the default spec strategy mode, the cpio strategy mode makes use of bundler to create a ´``vendor.obscpio`` file.
+This has the advantage that you can also use gems from sources other than rubygems.org and nothing gets written to your spec file (you don't need the ```# GEMS START``` marker).
+Most of the description from the spec strategy mode (default) applies as well in this mode.
+However, you need to explictly set the strategy to `cpio` in your service file with:
+
+```xml
+<service name="bundle_gems" mode="disabled">
+  <param name="strategy">cpio</param>
+</service>
+```
+
+The vendor obscpio gets automatically unpacked during build. The gems are located under ``rpmbuild/SOURCES/vendor/bundle/vendor/cache`` in your build environment.
+
 # Authors
 
 * Duncan Mac-Vicar P. <dmacvicar@suse.de>
@@ -108,4 +124,3 @@ $bundle --local --deployment --with production
 # License
 
 The code is licensed under the GPLv2 or later.
-

--- a/bundle_gems
+++ b/bundle_gems
@@ -18,6 +18,8 @@ require 'tempfile'
 require 'logger'
 require 'fileutils'
 require 'optparse'
+require 'fileutils'
+require 'open3'
 
 logger = Logger.new(STDOUT)
 logger.level = Logger::INFO
@@ -27,11 +29,16 @@ logger.formatter = proc do |severity, datetime, progname, msg|
   "[#{date_format}] #{severity.ljust(5)} (#{progname}): #{msg}\n"
 end
 
-options = {}
+options = { strategy: :spec }
 OptionParser.new do |opts|
   opts.banner = "Usage: #{ARGV[0]} [options]"
   opts.on('-oDIR', '--outdir=DIR', 'Output Directory') do |v|
     options[:outdir] = v
+  end
+  strategies = %i[cpio spec]
+  msg = "Choose the strategy the service runs in. Options: #{strategies.join(', ')}"
+  opts.on('--strategy=STRING', strategies, msg) do |v|
+    options[:strategy] = v
   end
 end.parse!
 
@@ -57,6 +64,55 @@ unless File.exist?(gem_file_lock)
   exit(1)
 end
 logger.info "Using #{gem_file_lock}"
+
+if options[:strategy] == :cpio
+  FileUtils.cp ['Gemfile', 'Gemfile.lock'], options[:outdir]
+  if File.file? 'vendor.obscpio'
+    logger.info 'Extracting vendor.obscpio...'
+    FileUtils.cp 'vendor.obscpio', options[:outdir]
+    Dir.chdir(options[:outdir]) do
+      stdout_and_stderr_str, status = Open3.capture2e(
+        'cpio -i --make-directories --format=newc < vendor.obscpio'
+      )
+      logger.info stdout_and_stderr_str
+      abort(stdout_and_stderr_str) unless status.success?
+    end
+  end
+
+  if ENV['OBS_SERVICE_BUNDLE_GEMS_MIRROR_URL']
+    Dir.chdir(options[:outdir]) do
+      mirror_url = ENV['OBS_SERVICE_BUNDLE_GEMS_MIRROR_URL']
+      stdout_and_stderr_str, status = Open3.capture2e("
+        bundle config --local mirror.http://rubygems.org #{mirror_url}")
+      logger.info stdout_and_stderr_str
+      abort(stdout_and_stderr_str) unless status.success?
+      stdout_and_stderr_str, status = Open3.capture2e(
+        "bundle config --local mirror.https://rubygems.org #{mirror_url}"
+      )
+      logger.info stdout_and_stderr_str
+      abort(stdout_and_stderr_str) unless status.success?
+    end
+  end
+
+  Dir.chdir(options[:outdir]) do
+    stdout_and_stderr_str, status = Open3.capture2e(
+      'bundle package --no-install --path vendor/bundle'
+    )
+    logger.info stdout_and_stderr_str
+    abort(stdout_and_stderr_str) unless status.success?
+    stdout_and_stderr_str, status = Open3.capture2e(
+      'find vendor/bundle/vendor/cache/ -depth -type f -print |' \
+      ' cpio --format=newc -o > vendor.obscpio'
+    )
+    abort(stdout_and_stderr_str) unless status.success?
+    logger.info stdout_and_stderr_str
+    FileUtils.rm ['Gemfile', 'Gemfile.lock']
+    FileUtils.remove_dir 'vendor'
+    FileUtils.remove_dir '.bundle'
+  end
+
+  exit 0
+end
 
 logger.info 'Resolving...'
 definition = Bundler::Definition.build('Gemfile', 'Gemfile.lock', nil)

--- a/bundle_gems.service
+++ b/bundle_gems.service
@@ -3,4 +3,7 @@
   <description>This service reads the Gemfile from the sources, figures out the whole chain
   of gem dependencies, and adds them to the source list so that another service like
   download_files can retrieve them.</description>
+  <parameter name="strategy">
+    <description>Choose the strategy this service runs in. Values: spec, cpio. Default: spec</description>
+  </parameter>
 </service>


### PR DESCRIPTION
This pull request implements a cpio mode to use bundler to create an obscpio archive instead of downloading all files into the package directory and adding it as sources.

To enable it, the service needs to get called like this:
```
<services>
   <service name="bundle_gems">
     <param name="cpio">true</param>
   </service>
</services>
```

Advantages:
- spec file does not get modified with every service run
- no markers in spec file necessary (``### GEM START``)
- not used gems get automatically removed
- bundler is used to download the gems instead of harcoding URLs
- using different sources other than rubygems is supported (e.g. branches from GitHub)

If the ```cpio=true``` is not specified, the service will work as before.

By default, a global cache (over all packages) is not enabled (the old mode does it implicit by making use of the download file service). It can be setup with setting up a local rubygems cache and setting the environment variable with e.g. ```OBS_SERVICE_BUNDLE_GEMS_MIRROR_URL=localhost```. On build.o.o we will make use of https://github.com/geminabox/geminabox.
