### PR TITLE
Fix documentation for vendor/cache path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ BuildRequires: rubygem(%{rb_default_ruby_abi}:bundler)
 
 ```
 mkdir -p vendor/cache
-cp %{_sourcedir}/*.gem vendor/cache
+cp %{_sourcedir}/vendor/cache/*.gem vendor/cache
 
 %build
 gem="gem.%{rb_default_ruby_suffix}"


### PR DESCRIPTION
reference: https://build.opensuse.org/package/view_file/OBS:Server:Unstable/obs-server/_service:obs_scm:obs-bundled-gems.spec?expand=1