### PR TITLE
Allow usage of a different ruby version 

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -33,3 +33,12 @@ jobs:
           mkdir outdir
           ../bundle_gems --strategy=cpio -o outdir
           file outdir/vendor.obscpio
+      - name: Test cpio strategy and ruby-version
+        run: |
+          sudo apt-get update
+          sudo apt-get install autoconf bison patch build-essential libssl-dev libyaml-dev libreadline-dev \
+            zlib1g-dev libgmp-dev libncurses-dev libffi-dev libgdbm-dev libdb-dev uuid-dev rbenv ruby-build
+          cd spec
+          mkdir outdir
+          ../bundle_gems --strategy=cpio --ruby-version=2.7.6 -o outdir
+          file outdir/vendor.obscpio

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - name: Prepare tests
         run: |

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -39,6 +39,6 @@ jobs:
           sudo apt-get install autoconf bison patch build-essential libssl-dev libyaml-dev libreadline-dev \
             zlib1g-dev libgmp-dev libncurses-dev libffi-dev libgdbm-dev libdb-dev uuid-dev rbenv ruby-build
           cd spec
-          mkdir outdir
-          ../bundle_gems --strategy=cpio --ruby-version=2.7.6 -o outdir
-          file outdir/vendor.obscpio
+          mkdir outdir2
+          ../bundle_gems --strategy=cpio --ruby-version=2.7.6 -o outdir2
+          file outdir2/vendor.obscpio

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -33,12 +33,17 @@ jobs:
           mkdir outdir
           ../bundle_gems --strategy=cpio -o outdir
           file outdir/vendor.obscpio
-      - name: Test cpio strategy and ruby-version
+      - name: Install rbenv and ruby-build
         run: |
           sudo apt-get update
           sudo apt-get install autoconf bison patch build-essential libssl-dev libyaml-dev libreadline-dev \
-            zlib1g-dev libgmp-dev libncurses-dev libffi-dev libgdbm-dev libdb-dev uuid-dev rbenv ruby-build
+            zlib1g-dev libgmp-dev libncurses-dev libffi-dev libgdbm-dev libdb-dev uuid-dev rbenv wget jq
+          TAG=$(wget -q -O- https://api.github.com/repos/rbenv/ruby-build/releases/latest | jq -r '.tag_name')
+          mkdir -p "$(rbenv root)/plugins/ruby-build"
+          wget -q -O- https://github.com/rbenv/ruby-build/archive/refs/tags/${TAG}.tar.gz | tar xzf - -C "$(rbenv root)/plugins/ruby-build" --strip-components=1
+      - name: Test cpio strategy and ruby-version
+        run: |
           cd spec
           mkdir outdir2
-          ../bundle_gems --strategy=cpio --ruby-version=2.7.6 -o outdir2
+          ../bundle_gems --strategy=cpio --ruby-version=2.7.7 -o outdir2
           file outdir2/vendor.obscpio

--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ However, you need to explictly set the strategy to `cpio` in your service file w
 
 The vendor obscpio gets automatically unpacked during build. The gems are located under ``rpmbuild/SOURCES/vendor/cache`` in your build environment.
 
+### Specific Ruby interpreter version (using rbenv)
+You can choose if needed the ruby version used to install the gems packed in the ``vendor.obscpio`` file:
+```xml
+<service name="bundle_gems">
+  <param name="strategy">cpio</param>
+  <param name="ruby-version">2.7.6</param>
+</service>
+```
+
+It can be useful to build gems that have strong dependencies on the ruby interpreter (ie ``nokogiri``). The specified version is installed by ``rbenv`` (if not already present).
+``rbenv`` and ``ruby-build`` are required.
+
 # Authors
 
 * Duncan Mac-Vicar P. <dmacvicar@suse.de>

--- a/bundle_gems
+++ b/bundle_gems
@@ -69,7 +69,7 @@ if rversion && options[:strategy] == :cpio
     @logger.fatal 'rbenv is either not installed or not in PATH'
     exit(1)
   end
-  
+
   @logger.info "Installing Ruby #{rversion} using rbenv"
   run_command(command: "rbenv install --skip-existing \"#{rversion}\"")
 

--- a/bundle_gems
+++ b/bundle_gems
@@ -69,15 +69,10 @@ if rversion && options[:strategy] == :cpio
     @logger.fatal 'rbenv is either not installed or not in PATH'
     exit(1)
   end
+  
+  @logger.info "Installing Ruby #{rversion} using rbenv"
+  run_command(command: "rbenv install --skip-existing \"#{rversion}\"")
 
-  if run_command_with_status(command: "rbenv versions | grep -qw \"#{rversion}\"") == 1
-    unless run_command_with_status(command: "rbenv install -L | grep -qw \"#{rversion}\"").zero?
-      @logger.fatal "No Ruby version \"#{rversion}\" available with rbenv"
-      exit(1)
-    end
-    @logger.info "Installing Ruby #{rversion} using rbenv"
-    run_command(command: "rbenv install \"#{rversion}\"")
-  end
   @logger.info "Setting up Ruby #{rversion} PATH using rbenv"
   run_command(command: "rbenv local \"#{rversion}\"")
   prefix = `rbenv prefix`.chomp

--- a/bundle_gems
+++ b/bundle_gems
@@ -40,9 +40,53 @@ OptionParser.new do |opts|
   opts.on('--strategy=STRING', strategies, msg) do |v|
     options[:strategy] = v
   end
+  opts.on('-rVERSION', '--ruby-version=VERSION', 'Ruby version (using rbenv)') do |v|
+    options[:rversion] = v
+  end
 end.parse!
 
 outdir = options[:outdir] || Dir.pwd
+rversion = options[:rversion] || nil
+
+def command?(command)
+  system("which #{command} > /dev/null 2>&1")
+end
+
+def run_command(command:, environment: {})
+  stdout_and_stderr_str, status = Open3.capture2e(environment, command)
+  @logger.info stdout_and_stderr_str
+  abort(stdout_and_stderr_str) unless status.success?
+end
+
+def run_command_with_status(command:, environment: {})
+  stdout_and_stderr_str, status = Open3.capture2e(environment, command)
+  @logger.info stdout_and_stderr_str
+  status.exitstatus
+end
+
+if rversion && options[:strategy] == :cpio
+  unless command?('rbenv')
+    @logger.fatal 'rbenv is either not installed or not in PATH'
+    exit(1)
+  end
+
+  if run_command_with_status(command: "rbenv versions | grep -qw \"#{rversion}\"") == 1
+    unless run_command_with_status(command: "rbenv install -L | grep -qw \"#{rversion}\"").zero?
+      @logger.fatal "No Ruby version \"#{rversion}\" available with rbenv"
+      exit(1)
+    end
+    @logger.info "Installing Ruby #{rversion} using rbenv"
+    run_command(command: "rbenv install \"#{rversion}\"")
+  end
+  @logger.info "Setting up Ruby #{rversion} PATH using rbenv"
+  run_command(command: "rbenv local \"#{rversion}\"")
+  prefix = `rbenv prefix`.chomp
+  run_command(command: 'rbenv local --unset')
+  cmd = "#{$PROGRAM_NAME} --outdir=#{outdir} --strategy=#{options[:strategy]}"
+  stdout_and_stderr_str, status = Open3.capture2e({ 'PATH' => "#{prefix}/bin:#{ENV['PATH']}" }, cmd)
+  puts stdout_and_stderr_str
+  exit(status.exitstatus)
+end
 
 # Find Gemfile (matches _service:obs_scm:Gemfile and Gemfile)
 gem_file = Dir.glob('*Gemfile').first.to_s
@@ -68,12 +112,6 @@ File.readlines(gem_file_lock).each do |line|
   next_line = true if line.start_with?('BUNDLED WITH')
 end
 @bundledwith = @bundledwith.lstrip.chomp if @bundledwith
-
-def run_command(command:, environment: {})
-  stdout_and_stderr_str, status = Open3.capture2e(environment, command)
-  @logger.info stdout_and_stderr_str
-  abort(stdout_and_stderr_str) unless status.success?
-end
 
 def bundle(command:)
   if @bundler_directory

--- a/bundle_gems.service
+++ b/bundle_gems.service
@@ -6,4 +6,7 @@
   <parameter name="strategy">
     <description>Choose the strategy this service runs in. Values: spec, cpio. Default: spec</description>
   </parameter>
+  <parameter name="ruby-version">
+    <description>Choose the Ruby version used to install gems. rbenv is used to install/run ruby, only usable with "cpio" strategy.</description>
+  </parameter>
 </service>


### PR DESCRIPTION
It's sometimes needed to use a ruby version different from the system one, for example:
```
nokogiri-1.13.6 requires ruby version >= 2.6.0, which is incompatible with the
current version, ruby 2.5.9p229
Bundler::InstallError: nokogiri-1.13.6 requires ruby version >= 2.6.0, which is incompatible with the current version, ruby 2.5.9p229
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/installer.rb:249:in `block in ensure_specs_are_compatible!'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/spec_set.rb:147:in `each'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/spec_set.rb:147:in `each'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/installer.rb:246:in `ensure_specs_are_compatible!'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/installer.rb:85:in `block in run'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/process_lock.rb:12:in `block in lock'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/process_lock.rb:9:in `open'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/process_lock.rb:9:in `lock'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/installer.rb:73:in `run'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/installer.rb:25:in `install'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/cli/install.rb:66:in `run'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/cli/cache.rb:33:in `install'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/cli/cache.rb:17:in `run'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/cli.rb:461:in `cache'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:399:in `dispatch'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/cli.rb:30:in `dispatch'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:476:in `start'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/cli.rb:24:in `start'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/exe/bundle:46:in `block in '
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/gems/bundler-2.1.4/exe/bundle:34:in `'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/bin/bundle:23:in `load'
/var/cache/obs/uKzLdxzLG7Jg/src/d20221125-8-1el9ihs/bin/bundle:23:in `'
```

Add the `--ruby-version` param: the service will install the specified version using `rbenv` and use it to run gem, this is  only needed in `cpio` strategy.

As `rbenv` root default is `~/.rbenv/` the service will only trigger the install the first time the specified  version is requested, the main drawback is that each ruby install consumes ~ 100MB of storage.

The machines running the service would need `rbenv` and a pretty recent `ruby-build` packages for this to work properly.
